### PR TITLE
Modified error strings

### DIFF
--- a/src/pwstrength.js
+++ b/src/pwstrength.js
@@ -19,8 +19,8 @@
             minChar: 8,
             bootstrap3: false,
             errorMessages: {
-                password_too_short: "<font color='red'>The Password is too short</font>",
-                same_as_username: "Your password cannot be the same as your username"
+                password_too_short: '<span style="color: #d52929">The Password is too short</font>',
+                same_as_username: "Your password cannot contain your username"
             },
             scores: [17, 26, 40, 50],
             verdicts: ["Weak", "Normal", "Medium", "Strong", "Very Strong"],


### PR DESCRIPTION
The "too short" error string used the deprecated 'font' tag, and
the username string incorrectly stated that the password could not
_be_ the username, when in fact the password cannot _contain_ the
username.
