### PR TITLE
Adding option: strictSecurity

### DIFF
--- a/src/pwstrength.js
+++ b/src/pwstrength.js
@@ -268,6 +268,10 @@
                 localOptions = $el.data("pwstrength");
 
             $.each(localOptions.rules, function (rule, active) {
+                if((rule == "wordRepetitions" || rule == "wordTwoCharacterClasses") 
+                   && !localOptions.strictSecurity) {
+                    active = false;
+                }
                 if (active === true) {
                     var score = localOptions.ruleScores[rule],
                         result = localOptions.validationRules[rule](localOptions, word, score);


### PR DESCRIPTION
If strictSecurity is set to true, additional errorMessages will be displayed and two new rules are applied.
1. check for repetitions
2. check for characters from at least two different character classes/sets
