### PR TITLE
Changing Default Behavior

### DIFF
--- a/examples/pwstrength.js
+++ b/examples/pwstrength.js
@@ -365,6 +365,9 @@ var ui = {};
         if (options.ui.showProgressBar) {
             ui.initProgressBar(options, $el);
         }
+        if ($el.val()) {
+            $el.pwstrength('forceUpdate');
+        }
     };
 
     ui.possibleProgressBarClasses = ["danger", "warning", "success"];

--- a/src/ui.js
+++ b/src/ui.js
@@ -121,6 +121,9 @@ var ui = {};
         if (options.ui.showProgressBar) {
             ui.initProgressBar(options, $el);
         }
+        if ($el.val()) {
+            $el.pwstrength('forceUpdate');
+        }
     };
 
     ui.possibleProgressBarClasses = ["danger", "warning", "success"];


### PR DESCRIPTION
**If input has existing text run the update to get the strength**

I'm using this for a password generator.  The textbox is sometimes filled in before the page is loaded.

If there is existing text in the textbox -> run the update to get the strength.

See this jsfiddle

http://jsfiddle.net/9MWQ8/2/

I can achieve this also by calling $(element).pwstrength('forceUpdate'); in the onLoad or success (for ajax calls)
