### PR TITLE
Escape special characters in username before using it as a regular expression

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -46,7 +46,7 @@ try {
 
     validation.wordSimilarToUsername = function (options, word, score) {
         var username = $(options.common.usernameField).val();
-        if (username && word.toLowerCase().match(username.toLowerCase())) {
+        if (username && word.toLowerCase().match(username.replace(/[\-\[\]\/\{\}\(\)\*\+\=\?\:\.\\\^\$\|\!\,]/g, "\\$&").toLowerCase())) {
             return score;
         }
         return 0;


### PR DESCRIPTION
This escapes all special characters in the username before sending it to `word.match`.  This creates the correct regular expression from the string value and prevents it from throwing a syntax error if, for example, the username started with a `+`.

I escaped all special characters listed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions?redirectlocale=en-US&redirectslug=JavaScript%2FGuide%2FRegular_Expressions).