### PR TITLE
Replace entropy call with log2 of guesses for zxcvbn

### DIFF
--- a/.idea/jquery.pwstrength.bootstrap.iml
+++ b/.idea/jquery.pwstrength.bootstrap.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/methods.js
+++ b/src/methods.js
@@ -37,7 +37,7 @@ var methods = {};
                     if (value) { userInputs.push(value); }
                 });
                 userInputs = userInputs.concat(options.common.zxcvbnTerms);
-                score = zxcvbn(word, userInputs).entropy;
+                score = Math.log2(zxcvbn(word, userInputs).guesses);
             } else {
                 score = rulesEngine.executeRules(options, word);
             }


### PR DESCRIPTION
entropy property is removed in zxcvbn v4.0.1, and it was just log2 of
guesses