### PR TITLE
Fix "errors" string in Portuguese

### DIFF
--- a/locales/pt.json
+++ b/locales/pt.json
@@ -7,7 +7,7 @@
     "wordTwoCharacterClasses": "Use diferentes classes de caracteres",
     "wordRepetitions": "Muitas repetições",
     "wordSequences": "Sua senha contém sequências",
-    "errorList": "Errores:",
+    "errorList": "Erros:",
     "veryWeak": "Muito Fraca",
     "weak": "Fraca",
     "normal": "Normal",


### PR DESCRIPTION
"Errores" is Spanish. In Portuguese, it's "Erros".
https://en.wiktionary.org/wiki/errores
https://en.wiktionary.org/wiki/erros