### PR TITLE
fix French string capitalization

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -13,5 +13,5 @@
     "normal": "Normal",
     "medium": "Moyen",
     "strong": "Fort",
-    "veryStrong": "Très fort"
+    "veryStrong": "Très Fort"
 }


### PR DESCRIPTION
The capitalization was not consistent within the French translation. Since the originals are "Very Weak" and "Very Strong" (both capitalized), I'm capitalizing "Très fort".