### PR TITLE
fixed typo in de.json

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,7 +1,7 @@
 {
     "wordMinLength": "Das Passwort ist zu kurz",
     "wordMaxLength": "Das Passwort ist zu lang",
-    "wordInvalidChar": "Das Passwort Enthält ein ungültiges Zeichen",
+    "wordInvalidChar": "Das Passwort enthält ein ungültiges Zeichen",
     "wordNotEmail": "Das Passwort darf die E-Mail Adresse nicht enthalten",
     "wordSimilarToUsername": "Das Passwort darf den Benutzernamen nicht enthalten",
     "wordTwoCharacterClasses": "Bitte Buchstaben und Ziffern verwenden",


### PR DESCRIPTION
Fixed typo for `"wordInvalidChar": "Das Passwort enthält ein ungültiges Zeichen"`.

Compare to line 9: `"wordSequences": "Das Passwort enthält Buchstabensequenzen"`.