### PR TITLE
Replacing the usage of isNumeric, which has been removed in jQuery 4.0.0, with isNaN and isFinite

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -195,7 +195,7 @@ var methods = {};
             }
             if (typeof ruleFunction === 'function') {
                 result = ruleFunction(options, $(el).val(), 1);
-                if ($.isNumeric(result)) {
+                if (!isNaN(parseFloat(result)) && isFinite(result)) {
                     rulesMetCnt += result;
                 }
             }

--- a/src/rules.js
+++ b/src/rules.js
@@ -237,7 +237,7 @@ try {
                     if (result) {
                         totalScore += result;
                     }
-                    if (result < 0 || (!$.isNumeric(result) && !result)) {
+                    if (result < 0 || (isNaN(parseFloat(result)) || !isFinite(result)) && !result) {
                         errorMessage = options.ui.spanError(options, rule);
                         if (errorMessage.length > 0) {
                             options.instances.errors.push(errorMessage);


### PR DESCRIPTION
This PR updates the usage of jQuery's `$.isNumeric`. As this function was deprecated in jQuery 3.0 and **removed** entirely in [4.0.0](https://api.jquery.com/jQuery.isNumeric/), we are replacing it with a recommended alternative (e.g., Number.isFinite()) to ensure future compatibility and prevent potential errors.